### PR TITLE
Fixes the issue "ConnectionSuccessListener always returns successful"

### DIFF
--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
@@ -29,6 +29,7 @@ public final class ConnectorUtils {
     public static boolean isAlreadyConnected(@Nullable WifiManager wifiManager, @Nullable String bssid) {
         if (bssid != null && wifiManager != null) {
             if (wifiManager.getConnectionInfo() != null && wifiManager.getConnectionInfo().getBSSID() != null &&
+                    wifiManager.getConnectionInfo().getIpAddress() != 0 &&
                     Objects.equals(bssid, wifiManager.getConnectionInfo().getBSSID())) {
                 wifiLog("Already connected to: " + wifiManager.getConnectionInfo().getSSID() + "  BSSID: " + wifiManager.getConnectionInfo().getBSSID());
                 return true;

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiUtils.java
@@ -29,7 +29,6 @@ import static com.thanosfisherman.elvis.Elvis.of;
 import static com.thanosfisherman.wifiutils.ConnectorUtils.cleanPreviousConfiguration;
 import static com.thanosfisherman.wifiutils.ConnectorUtils.connectToWifi;
 import static com.thanosfisherman.wifiutils.ConnectorUtils.connectWps;
-import static com.thanosfisherman.wifiutils.ConnectorUtils.isAlreadyConnected;
 import static com.thanosfisherman.wifiutils.ConnectorUtils.matchScanResult;
 import static com.thanosfisherman.wifiutils.ConnectorUtils.matchScanResultBssid;
 import static com.thanosfisherman.wifiutils.ConnectorUtils.matchScanResultSsid;
@@ -122,15 +121,13 @@ public final class WifiUtils implements WifiConnectorBuilder,
             }
             if (mSingleScanResult != null && mPassword != null)
             {
-                //Do I really need dis? Not sure yet
-                if (isAlreadyConnected(mWifiManager, mSingleScanResult.BSSID))
-                {
-                    mWifiConnectionCallback.successfulConnect();
-                    return;
-                }
                 if (connectToWifi(mContext, mWifiManager, mSingleScanResult, mPassword))
+                {
                     registerReceiver(mContext, mWifiConnectionReceiver.activateTimeoutHandler(mSingleScanResult),
-                                     new IntentFilter(WifiManager.SUPPLICANT_STATE_CHANGED_ACTION));
+                            new IntentFilter(WifiManager.SUPPLICANT_STATE_CHANGED_ACTION));
+                    registerReceiver(mContext, mWifiConnectionReceiver,
+                            new IntentFilter(WifiManager.NETWORK_STATE_CHANGED_ACTION));
+                }
                 else
                     mWifiConnectionCallback.errorConnect();
             }

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/WifiConnectionReceiver.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/WifiConnectionReceiver.java
@@ -52,7 +52,20 @@ public final class WifiConnectionReceiver extends BroadcastReceiver
     public void onReceive(Context context, @NonNull Intent intent)
     {
         final String action = intent.getAction();
-        if (Objects.equals(WifiManager.SUPPLICANT_STATE_CHANGED_ACTION, action))
+        wifiLog("Connection Broadcast action: " + action);
+        if (Objects.equals(WifiManager.NETWORK_STATE_CHANGED_ACTION, action))
+        {
+            /*
+                Note here we dont check if has internet connectivity, because we only validate
+                if the connection to the hotspot is active, and not if the hotspot has internet.
+             */
+            if (isAlreadyConnected(mWifiManager, of(mScanResult).next(scanResult -> scanResult.BSSID).get()))
+            {
+                handler.removeCallbacks(handlerCallback);
+                mWifiConnectionCallback.successfulConnect();
+            }
+        }
+        else if (Objects.equals(WifiManager.SUPPLICANT_STATE_CHANGED_ACTION, action))
         {
             final SupplicantState state = intent.getParcelableExtra(WifiManager.EXTRA_NEW_STATE);
             final int supl_error = intent.getIntExtra(WifiManager.EXTRA_SUPPLICANT_ERROR, -1);


### PR DESCRIPTION
Fixes #5 

Why is this change needed?
   To fix the false positive for the wifi connection

How does it address the issue?
   Only returns success when the connection with the hotspot is made successfully after authentication process (SupplicantState.COMPLETED), and checks if we received the ip from the network. This prevents the scenario that the authentication process returns success, but with the connection in state "Obtaining ip address".