### PR TITLE
Implementation Replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Add the following to your **app module** `build.gradle` file
     
 ```groovy
     dependencies {
-       compile 'com.thanosfisherman.wifiutils:wifiutils:<latest version here>'
+       implementation 'com.thanosfisherman.wifiutils:wifiutils:<latest version here>'
     }
 ```
     


### PR DESCRIPTION
#### Description

gradle 3.0+ deprecated compile which is replaced with implementation

#### Solution

Replaced compile with implementation as it is deprecated in 2018.