### PR TITLE
Connect on Android Q

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
@@ -25,10 +25,10 @@ task clean(type: Delete) {
 
 
 ext {
-    compileSdkVersion = 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion = 29
+    buildToolsVersion = '29.0.0'
     minSdkVersion = 15
-    targetSdkVersion = 28
+    targetSdkVersion = 29
     publishVersionName = '1.4.2'
     publishVersionCode = 14
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
@@ -1,8 +1,12 @@
 package com.thanosfisherman.wifiutils;
 
+import android.annotation.TargetApi;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
+import android.net.wifi.WifiNetworkSpecifier;
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -96,6 +100,28 @@ final class ConfigSecurities {
 
             default:
                 wifiLog("Invalid security type: " + security);
+                break;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    static void setupWifiNetworkSpecifierSecurities(@NonNull WifiNetworkSpecifier.Builder wifiNetworkSpecifierBuilder, String security, @NonNull final String password) {
+        wifiLog("Setting up WifiNetworkSpecifier.Builder " + security);
+        switch (security) {
+            case SECURITY_NONE:
+                // nothing to do
+                break;
+            case SECURITY_WEP:
+                // no longer possible
+                break;
+            case SECURITY_PSK:
+            case SECURITY_EAP:
+                wifiNetworkSpecifierBuilder.setWpa2Passphrase(password);
+                break;
+
+            default:
+                wifiLog("Invalid security type: " + security);
+                break;
         }
     }
 


### PR DESCRIPTION
#### Description

On Android Q/10 (sdk 29) it is no longer possible to connect to a wifi network via WifiManager.enableNetwork(WifiConfiguration). I've implemented the required changes.


Related issues: 
* https://github.com/ThanosFisherman/WifiUtils/issues/45
* https://github.com/ThanosFisherman/WifiUtils/issues/43
* https://github.com/ThanosFisherman/WifiUtils/issues/31
* https://github.com/ThanosFisherman/WifiUtils/issues/36

#### Solution

As you can see in the PR, I create a WifiNetworkSpecifier. With that, I do ConnectivityManager.requestNetwork(NetworkRequest).
Once the network is available, i bind it so the complete app can execute api calls over the wifi network.

Currently only tested with a wpa2 network. Other apps or the OS can't use this network. When your app is stopped, the network connection is stopped. This is completely my case (connect to an IoT AP, perform setup). I am not sure how others use this library?
