### PR TITLE
AndroidQ small improvement; remove bindProcessToNetwork

### DIFF
--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
@@ -292,9 +292,6 @@ public final class ConnectorUtils {
                 super.onAvailable(network);
 
                 wifiLog("AndroidQ+ connected to wifi ");
-
-                // bind so all api calls are performed over this new network
-                connectivityManager.bindProcessToNetwork(network);
             }
 
             @Override


### PR DESCRIPTION
Small change to the android Q connect; bindProcessToNetwork is only required for executing api calls to networks without internet. This is not something for WifiUtils to fix (as you also have to unbind).

By doing this, when the network was lost, the app that initiated the connect to network actually loses internet connectivity until unbind is called.