### PR TITLE
Feature/disconnect from wifi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
@@ -25,10 +25,10 @@ task clean(type: Delete) {
 
 
 ext {
-    compileSdkVersion = 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion = 29
+    buildToolsVersion = '29.0.0'
     minSdkVersion = 15
-    targetSdkVersion = 28
+    targetSdkVersion = 29
     publishVersionName = '1.4.2'
     publishVersionCode = 14
 

--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
@@ -51,8 +51,7 @@ public class MainActivity extends AppCompatActivity {
 
     private void disconnect(final Context context) {
         WifiUtils.withContext(context)
-                .disconnectFrom(SSID)
-                .onDisconnectionResult(new DisconnectionSuccessListener() {
+                .disconnectFrom(SSID, new DisconnectionSuccessListener() {
                     @Override
                     public void success() {
                         Toast.makeText(MainActivity.this, "Disconnect success!", Toast.LENGTH_SHORT).show();
@@ -62,8 +61,7 @@ public class MainActivity extends AppCompatActivity {
                     public void failed(@NonNull DisconnectionErrorCode errorCode) {
                         Toast.makeText(MainActivity.this, "Failed to disconnect: " + errorCode.toString(), Toast.LENGTH_SHORT).show();
                     }
-                })
-                .start();
+                });
     }
 
     private void enableWifi() {

--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
@@ -18,10 +18,11 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
         ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, 555);
-        final Button button = findViewById(R.id.button);
         WifiUtils.enableLog(true);
         //TODO: CHECK IF LOCATION SERVICES ARE ON
-        button.setOnClickListener(v -> connectWithWpa());
+
+        final Button buttonConnect = findViewById(R.id.button_connect);
+        buttonConnect.setOnClickListener(v -> connectWithWpa());
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)

--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
@@ -1,17 +1,25 @@
 package com.thanosfisherman.wifiutils.sample;
 
 import android.Manifest;
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
 import android.widget.Button;
 import android.widget.Toast;
 
 import com.thanosfisherman.wifiutils.WifiUtils;
+import com.thanosfisherman.wifiutils.wifiDisconnect.DisconnectionErrorCode;
+import com.thanosfisherman.wifiutils.wifiDisconnect.DisconnectionSuccessListener;
 
 public class MainActivity extends AppCompatActivity {
+    final static String SSID = "conn-x828678";
+    static final String PASSWORD = "146080828678";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -23,6 +31,9 @@ public class MainActivity extends AppCompatActivity {
 
         final Button buttonConnect = findViewById(R.id.button_connect);
         buttonConnect.setOnClickListener(v -> connectWithWpa());
+
+        final Button buttonDisconnect = findViewById(R.id.button_disconnect);
+        buttonDisconnect.setOnClickListener(v -> disconnect(v.getContext()));
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
@@ -31,13 +42,27 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void connectWithWpa() {
-        String ote = "conn-x828678";
-        String otePass = "146080828678";
-
         WifiUtils.withContext(getApplicationContext())
-                .connectWith(ote, otePass)
+                .connectWith(SSID, PASSWORD)
                 .setTimeout(40000)
                 .onConnectionResult(this::checkResult)
+                .start();
+    }
+
+    private void disconnect(final Context context) {
+        WifiUtils.withContext(context)
+                .disconnectFrom(SSID)
+                .onDisconnectionResult(new DisconnectionSuccessListener() {
+                    @Override
+                    public void success() {
+                        Toast.makeText(MainActivity.this, "Disconnect success!", Toast.LENGTH_SHORT).show();
+                    }
+
+                    @Override
+                    public void failed(@NonNull DisconnectionErrorCode errorCode) {
+                        Toast.makeText(MainActivity.this, "Failed to disconnect: " + errorCode.toString(), Toast.LENGTH_SHORT).show();
+                    }
+                })
                 .start();
     }
 

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -8,16 +8,25 @@
     tools:context="com.thanosfisherman.wifiutils.sample.MainActivity">
 
     <Button
-        android:id="@+id/button"
+        android:id="@+id/button_connect"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Button"
-        app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginTop="8dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_marginBottom="8dp"
-        android:layout_marginLeft="8dp"
+        android:layout_margin="8dp"
+        android:text="@string/connect"
+        app:layout_constraintBottom_toBottomOf="@id/button_disconnect"
         app:layout_constraintLeft_toLeftOf="parent"
-        android:layout_marginRight="8dp"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/button_disconnect"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="8dp"
+        android:text="@string/disconnect"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button_connect"
+        app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">WifiUtils</string>
+    <string name="connect">Connect</string>
+    <string name="disconnect">Disconnect</string>
 </resources>

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
@@ -1,8 +1,12 @@
 package com.thanosfisherman.wifiutils;
 
+import android.annotation.TargetApi;
 import android.net.wifi.ScanResult;
 import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
+import android.net.wifi.WifiNetworkSpecifier;
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -96,6 +100,28 @@ final class ConfigSecurities {
 
             default:
                 wifiLog("Invalid security type: " + security);
+                break;
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.Q)
+    static void setupWifiNetworkSpecifierSecurities(@NonNull WifiNetworkSpecifier.Builder wifiNetworkSpecifierBuilder, String security, @NonNull final String password) {
+        wifiLog("Setting up WifiNetworkSpecifier.Builder " + security);
+        switch (security) {
+            case SECURITY_NONE:
+                // nothing to do
+                break;
+            case SECURITY_WEP:
+                // no longer possible
+                break;
+            case SECURITY_PSK:
+            case SECURITY_EAP:
+                wifiNetworkSpecifierBuilder.setWpa2Passphrase(password);
+                break;
+
+            default:
+                wifiLog("Invalid security type: " + security);
+                break;
         }
     }
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
@@ -19,8 +19,8 @@ import java.util.List;
 
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static android.Manifest.permission.ACCESS_WIFI_STATE;
-import static com.thanosfisherman.wifiutils.ConnectorUtils.convertToQuotedString;
 import static com.thanosfisherman.wifiutils.WifiUtils.wifiLog;
+import static com.thanosfisherman.wifiutils.utils.SSIDUtils.convertToQuotedString;
 
 final class ConfigSecurities {
     static final String SECURITY_NONE = "OPEN";
@@ -158,16 +158,30 @@ final class ConfigSecurities {
         return null;
     }
 
+    @Nullable
+    static WifiConfiguration getWifiConfiguration(@NonNull final WifiManager wifiManager, @NonNull final String ssid) {
+        final List<WifiConfiguration> configuredNetworks = wifiManager.getConfiguredNetworks();
+        final String findSSID = ('"' + ssid + '"');
+
+        for (final WifiConfiguration wifiConfiguration : configuredNetworks) {
+            if (wifiConfiguration.SSID.equals(findSSID)) {
+                return wifiConfiguration;
+            }
+        }
+
+        return null;
+    }
+
     @RequiresPermission(allOf = {ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE})
     @Nullable
-    static WifiConfiguration getWifiConfiguration(@NonNull final WifiManager wifiMgr, @NonNull final ScanResult scanResult) {
+    static WifiConfiguration getWifiConfiguration(@NonNull final WifiManager wifiManager, @NonNull final ScanResult scanResult) {
         if (scanResult.BSSID == null || scanResult.SSID == null || scanResult.SSID.isEmpty() || scanResult.BSSID.isEmpty())
             return null;
         final String ssid = convertToQuotedString(scanResult.SSID);
         final String bssid = scanResult.BSSID;
         final String security = getSecurity(scanResult);
 
-        final List<WifiConfiguration> configurations = wifiMgr.getConfiguredNetworks();
+        final List<WifiConfiguration> configurations = wifiManager.getConfiguredNetworks();
         if (configurations == null)
             return null;
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
@@ -34,6 +34,7 @@ import java.util.List;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static android.Manifest.permission.ACCESS_WIFI_STATE;
 import static com.thanosfisherman.wifiutils.WifiUtils.wifiLog;
+import static com.thanosfisherman.wifiutils.utils.SSIDUtils.convertToQuotedString;
 
 @SuppressLint("MissingPermission")
 public final class ConnectorUtils {
@@ -127,18 +128,6 @@ public final class ConnectorUtils {
         return i;
     }
 
-    @NonNull
-    static String convertToQuotedString(@NonNull String string) {
-        if (TextUtils.isEmpty(string))
-            return "";
-
-        final int lastPos = string.length() - 1;
-        if (lastPos < 0 || (string.charAt(0) == '"' && string.charAt(lastPos) == '"'))
-            return string;
-
-        return "\"" + string + "\"";
-    }
-
     static boolean isHexWepKey(@Nullable String wepKey) {
         final int passwordLen = wepKey == null ? 0 : wepKey.length();
         return (passwordLen == 10 || passwordLen == 26 || passwordLen == 58) && wepKey.matches("[0-9A-Fa-f]*");
@@ -178,11 +167,8 @@ public final class ConnectorUtils {
     }
 
     @RequiresPermission(ACCESS_WIFI_STATE)
-    static boolean disconnectFromWifi(@NonNull Context context, @Nullable ConnectivityManager connectivityManager, @Nullable WifiManager wifiManager, @NonNull ScanResult scanResult) {
+    static boolean disconnectFromWifi(@NonNull Context context, @NonNull ConnectivityManager connectivityManager, @NonNull WifiManager wifiManager, @NonNull String ssid) {
         if (isAndroidQOrLater()) {
-            if (connectivityManager == null)
-                return false;
-
             if (networkCallback != null) {
                 connectivityManager.unregisterNetworkCallback(networkCallback);
                 networkCallback = null;
@@ -191,7 +177,8 @@ public final class ConnectorUtils {
             return true;
         }
 
-        return cleanPreviousConfiguration(wifiManager, scanResult);
+        final WifiConfiguration wifiConfiguration = ConfigSecurities.getWifiConfiguration(wifiManager, ssid);
+        return cleanPreviousConfiguration(wifiManager, wifiConfiguration);
     }
 
     @RequiresPermission(allOf = {ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE})

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
@@ -157,7 +157,7 @@ public final class ConnectorUtils {
         }
     }
 
-    static void unregisterReceiver(@NonNull Context context, @Nullable BroadcastReceiver receiver) {
+    static void unregisterReceiver(@NonNull final Context context, @Nullable final BroadcastReceiver receiver) {
         if (receiver != null) {
             try {
                 context.unregisterReceiver(receiver);
@@ -167,7 +167,7 @@ public final class ConnectorUtils {
     }
 
     @RequiresPermission(ACCESS_WIFI_STATE)
-    static boolean disconnectFromWifi(@NonNull Context context, @NonNull ConnectivityManager connectivityManager, @NonNull WifiManager wifiManager, @NonNull String ssid) {
+    static boolean disconnectFromWifi(@NonNull final Context context, @NonNull final ConnectivityManager connectivityManager, @NonNull final WifiManager wifiManager, @NonNull final String ssid) {
         if (isAndroidQOrLater()) {
             if (networkCallback != null) {
                 connectivityManager.unregisterNetworkCallback(networkCallback);
@@ -191,7 +191,7 @@ public final class ConnectorUtils {
     }
 
     @RequiresPermission(allOf = {ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE})
-    private static boolean connectPreAndroidQ(@NonNull Context context, @Nullable WifiManager wifiManager, @NonNull ScanResult scanResult, @NonNull String password) {
+    private static boolean connectPreAndroidQ(@NonNull final Context context, @Nullable final WifiManager wifiManager, @NonNull final ScanResult scanResult, @NonNull final String password) {
         if (wifiManager == null)
             return false;
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiConnectorBuilder.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiConnectorBuilder.java
@@ -31,8 +31,7 @@ public interface WifiConnectorBuilder {
         @NonNull
         WifiSuccessListener connectWith(@NonNull String ssid, @NonNull String bssid, @NonNull String password);
 
-        @NonNull
-        DisconnectSuccessListener disconnectFrom(@NonNull String ssid);
+        void disconnectFrom(@NonNull String ssid, @NonNull DisconnectionSuccessListener disconnectionSuccessListener);
 
         @NonNull
         WifiSuccessListener connectWithScanResult(@NonNull String password, @Nullable ConnectionScanResultsListener connectionScanResultsListener);
@@ -59,10 +58,5 @@ public interface WifiConnectorBuilder {
         @NonNull
         @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
         WifiConnectorBuilder onConnectionWpsResult(@Nullable ConnectionWpsListener successListener);
-    }
-
-    interface DisconnectSuccessListener {
-        @NonNull
-        WifiConnectorBuilder onDisconnectionResult(@Nullable DisconnectionSuccessListener successListener);
     }
 }

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiConnectorBuilder.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiConnectorBuilder.java
@@ -7,6 +7,7 @@ import androidx.annotation.RequiresApi;
 
 import com.thanosfisherman.wifiutils.wifiConnect.ConnectionScanResultsListener;
 import com.thanosfisherman.wifiutils.wifiConnect.ConnectionSuccessListener;
+import com.thanosfisherman.wifiutils.wifiDisconnect.DisconnectionSuccessListener;
 import com.thanosfisherman.wifiutils.wifiScan.ScanResultsListener;
 import com.thanosfisherman.wifiutils.wifiState.WifiStateListener;
 import com.thanosfisherman.wifiutils.wifiWps.ConnectionWpsListener;
@@ -29,6 +30,9 @@ public interface WifiConnectorBuilder {
 
         @NonNull
         WifiSuccessListener connectWith(@NonNull String ssid, @NonNull String bssid, @NonNull String password);
+
+        @NonNull
+        DisconnectSuccessListener disconnectFrom(@NonNull String ssid);
 
         @NonNull
         WifiSuccessListener connectWithScanResult(@NonNull String password, @Nullable ConnectionScanResultsListener connectionScanResultsListener);
@@ -55,5 +59,10 @@ public interface WifiConnectorBuilder {
         @NonNull
         @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
         WifiConnectorBuilder onConnectionWpsResult(@Nullable ConnectionWpsListener successListener);
+    }
+
+    interface DisconnectSuccessListener {
+        @NonNull
+        WifiConnectorBuilder onDisconnectionResult(@Nullable DisconnectionSuccessListener successListener);
     }
 }

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/utils/SSIDUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/utils/SSIDUtils.java
@@ -1,0 +1,19 @@
+package com.thanosfisherman.wifiutils.utils;
+
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+public class SSIDUtils {
+    @NonNull
+    public static String convertToQuotedString(@NonNull String ssid) {
+        if (TextUtils.isEmpty(ssid))
+            return "";
+
+        final int lastPos = ssid.length() - 1;
+        if (lastPos < 0 || (ssid.charAt(0) == '"' && ssid.charAt(lastPos) == '"'))
+            return ssid;
+
+        return "\"" + ssid + "\"";
+    }
+}

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiDisconnect/DisconnectionErrorCode.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiDisconnect/DisconnectionErrorCode.java
@@ -1,6 +1,7 @@
 package com.thanosfisherman.wifiutils.wifiDisconnect;
 
 public enum DisconnectionErrorCode {
-    COULD_NOT_PERFORM_WIFI_SCAN,
+    COULD_NOT_GET_WIFI_MANAGER,
+    COULD_NOT_GET_CONNECTIVITY_MANAGER,
     COULD_NOT_DISCONNECT,
 }

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiDisconnect/DisconnectionErrorCode.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiDisconnect/DisconnectionErrorCode.java
@@ -1,0 +1,6 @@
+package com.thanosfisherman.wifiutils.wifiDisconnect;
+
+public enum DisconnectionErrorCode {
+    COULD_NOT_PERFORM_WIFI_SCAN,
+    COULD_NOT_DISCONNECT,
+}

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiDisconnect/DisconnectionSuccessListener.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiDisconnect/DisconnectionSuccessListener.java
@@ -1,0 +1,9 @@
+package com.thanosfisherman.wifiutils.wifiDisconnect;
+
+import androidx.annotation.NonNull;
+
+public interface DisconnectionSuccessListener
+{
+    void success();
+    void failed(@NonNull DisconnectionErrorCode errorCode);
+}


### PR DESCRIPTION
#### Description

Since I use this repo to connect to an IoT device, I also want to be able to disconnect from it (once it is set up).

#### Solution

Because of android 10, I need to get a hold of the networkCallback object used to connect to the wifi network. Before android 10, I can just remove the configuration.

I've added a first implementation.
Possible improvements:
* Watch the wifi state to see if disconnection was successful.
* Reuse scan results or allow the library user to scan once and then use that scanresult multiple times as wifi scanning is getting limited (only a few times per minut) on android 10 and up.