### PR TITLE
Remove allowBackup from manifest.

### DIFF
--- a/wifiutils/src/main/AndroidManifest.xml
+++ b/wifiutils/src/main/AndroidManifest.xml
@@ -8,7 +8,6 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
 
     <application
-        android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true">
 

--- a/wifiutils/src/main/AndroidManifest.xml
+++ b/wifiutils/src/main/AndroidManifest.xml
@@ -8,8 +8,7 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
 
     <application
-        android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
#### Description

allowBackup should not be set for library projects. This can cause manifest merge errors.

#### Solution

Remove allowBackup from manifest.
