### PR TITLE
Feature/meaningful exceptions

### DIFF
--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
@@ -3,6 +3,8 @@ package com.thanosfisherman.wifiutils.sample;
 import android.Manifest;
 import android.os.Build;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import androidx.core.app.ActivityCompat;
 import androidx.appcompat.app.AppCompatActivity;
@@ -10,6 +12,8 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import com.thanosfisherman.wifiutils.WifiUtils;
+import com.thanosfisherman.wifiutils.wifiConnect.ConnectionErrorCode;
+import com.thanosfisherman.wifiutils.wifiConnect.ConnectionSuccessListener;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -36,7 +40,17 @@ public class MainActivity extends AppCompatActivity {
         WifiUtils.withContext(getApplicationContext())
                 .connectWith(ote, otePass)
                 .setTimeout(40000)
-                .onConnectionResult(this::checkResult)
+                .onConnectionResult(new ConnectionSuccessListener() {
+                    @Override
+                    public void success() {
+                        Toast.makeText(MainActivity.this, "SUCCESS!", Toast.LENGTH_SHORT).show();
+                    }
+
+                    @Override
+                    public void failed(@NonNull ConnectionErrorCode errorCode) {
+                        Toast.makeText(MainActivity.this, "EPIC FAIL!" + errorCode.toString(), Toast.LENGTH_SHORT).show();
+                    }
+                })
                 .start();
     }
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
@@ -156,7 +156,7 @@ public final class ConnectorUtils {
             return -1;
     }
 
-    static void registerReceiver(@NonNull Context context, @Nullable BroadcastReceiver receiver, @NonNull IntentFilter filter) {
+    static void registerReceiver(@NonNull final Context context, @Nullable final BroadcastReceiver receiver, @NonNull final IntentFilter filter) {
         if (receiver != null) {
             try {
                 context.registerReceiver(receiver, filter);
@@ -165,7 +165,7 @@ public final class ConnectorUtils {
         }
     }
 
-    static void unregisterReceiver(@NonNull Context context, @Nullable BroadcastReceiver receiver) {
+    static void unregisterReceiver(@NonNull final Context context, @Nullable final BroadcastReceiver receiver) {
         if (receiver != null) {
             try {
                 context.unregisterReceiver(receiver);
@@ -175,7 +175,7 @@ public final class ConnectorUtils {
     }
 
     @RequiresPermission(allOf = {ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE})
-    static boolean connectToWifi(@NonNull Context context, @Nullable WifiManager wifiManager, @NonNull ScanResult scanResult, @NonNull String password) {
+    static boolean connectToWifi(@NonNull final Context context, @Nullable final WifiManager wifiManager, @NonNull final ScanResult scanResult, @NonNull final String password) {
         if (wifiManager == null)
             return false;
 
@@ -188,7 +188,7 @@ public final class ConnectorUtils {
     }
 
     @RequiresPermission(allOf = {ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE})
-    private static boolean connectPreAndroidQ(@NonNull Context context, @Nullable WifiManager wifiManager, @NonNull ScanResult scanResult, @NonNull String password) {
+    private static boolean connectPreAndroidQ(@NonNull final Context context, @Nullable final WifiManager wifiManager, @NonNull final ScanResult scanResult, @NonNull final String password) {
         WifiConfiguration config = ConfigSecurities.getWifiConfiguration(wifiManager, scanResult);
         if (config != null && password.isEmpty()) {
             wifiLog("PASSWORD WAS EMPTY. TRYING TO CONNECT TO EXISTING NETWORK CONFIGURATION");

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/ConnectionErrorCode.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/ConnectionErrorCode.java
@@ -1,0 +1,33 @@
+package com.thanosfisherman.wifiutils.wifiConnect;
+
+/**
+ * Errors that can occur when trying to connect to a wifi network.
+ */
+public enum ConnectionErrorCode {
+    /**
+     * Starting Android 10, apps are no longer allowed to enable wifi.
+     * User has to manually do this.
+     */
+    COULD_NOT_ENABLE_WIFI,
+    /**
+     * Starting Android 9, it's only allowed to scan 4 times per 2 minuts in a foreground app.
+     * https://developer.android.com/guide/topics/connectivity/wifi-scan
+     */
+    COULD_NOT_SCAN,
+    /**
+     * If the wifi network is not in range, the security type is unknown and WifiUtils doesn't support
+     * connecting to the network.
+     */
+    DID_NOT_FIND_NETWORK_BY_SCANNING,
+    /**
+     * Authentication error occurred while trying to connect.
+     * The password could be incorrect or the user could have a saved network configuration with a
+     * different password!
+     */
+    AUTHENTICATION_ERROR_OCCURRED,
+    /**
+     * Could not connect in the timeout window.
+     */
+    TIMEOUT_OCCURRED,
+    COULD_NOT_CONNECT,
+}

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/ConnectionSuccessListener.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/ConnectionSuccessListener.java
@@ -1,6 +1,9 @@
 package com.thanosfisherman.wifiutils.wifiConnect;
 
+import androidx.annotation.NonNull;
+
 public interface ConnectionSuccessListener
 {
-    void isSuccessful(boolean isSuccess);
+    void success();
+    void failed(@NonNull ConnectionErrorCode errorCode);
 }

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/WifiConnectionCallback.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/WifiConnectionCallback.java
@@ -1,7 +1,9 @@
 package com.thanosfisherman.wifiutils.wifiConnect;
 
+import androidx.annotation.NonNull;
+
 public interface WifiConnectionCallback
 {
     void successfulConnect();
-    void errorConnect();
+    void errorConnect(@NonNull ConnectionErrorCode connectionErrorCode);
 }

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/WifiConnectionReceiver.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/wifiConnect/WifiConnectionReceiver.java
@@ -37,12 +37,12 @@ public final class WifiConnectionReceiver extends BroadcastReceiver {
             if (isAlreadyConnected(mWifiManager, of(mScanResult).next(scanResult -> scanResult.BSSID).get()))
                 mWifiConnectionCallback.successfulConnect();
             else
-                mWifiConnectionCallback.errorConnect();
+                mWifiConnectionCallback.errorConnect(ConnectionErrorCode.TIMEOUT_OCCURRED);
             handler.removeCallbacks(this);
         }
     };
 
-    public WifiConnectionReceiver(@NonNull WifiConnectionCallback callback, @NonNull WifiManager wifiManager, long delayMillis) {
+    public WifiConnectionReceiver(@NonNull final WifiConnectionCallback callback, @NonNull final WifiManager wifiManager, final long delayMillis) {
         this.mWifiConnectionCallback = callback;
         this.mWifiManager = wifiManager;
         this.mDelay = delayMillis;
@@ -50,7 +50,7 @@ public final class WifiConnectionReceiver extends BroadcastReceiver {
     }
 
     @Override
-    public void onReceive(Context context, @NonNull Intent intent) {
+    public void onReceive(final Context context, @NonNull final Intent intent) {
         final String action = intent.getAction();
         wifiLog("Connection Broadcast action: " + action);
         if (Objects.equals(WifiManager.NETWORK_STATE_CHANGED_ACTION, action)) {
@@ -68,7 +68,7 @@ public final class WifiConnectionReceiver extends BroadcastReceiver {
 
             if (state == null) {
                 handler.removeCallbacks(handlerCallback);
-                mWifiConnectionCallback.errorConnect();
+                mWifiConnectionCallback.errorConnect(ConnectionErrorCode.COULD_NOT_CONNECT);
                 return;
             }
 
@@ -86,7 +86,7 @@ public final class WifiConnectionReceiver extends BroadcastReceiver {
                     if (supl_error == WifiManager.ERROR_AUTHENTICATING) {
                         wifiLog("Authentication error...");
                         handler.removeCallbacks(handlerCallback);
-                        mWifiConnectionCallback.errorConnect();
+                        mWifiConnectionCallback.errorConnect(ConnectionErrorCode.AUTHENTICATION_ERROR_OCCURRED);
                     } else {
                         wifiLog("Disconnected. Re-attempting to connect...");
                         reEnableNetworkIfPossible(mWifiManager, mScanResult);


### PR DESCRIPTION
#### Description

The current implementation logs why it couldn't connect with a wifi network but doesn't provide any information the library users.

#### Solution

The ConnectionSuccessListeners now has 2 methods, one for success and one for failed.
There are more meaningful exceptions so that library users can inform the user to why it wasn't possible.

Example

```
.onConnectionResult(new ConnectionSuccessListener() {
                    @Override
                    public void success() {
                        Toast.makeText(MainActivity.this, "SUCCESS!", Toast.LENGTH_SHORT).show();
                    }

                    @Override
                    public void failed(@NonNull ConnectionErrorCode errorCode) {
                        Toast.makeText(MainActivity.this, "EPIC FAIL!" + errorCode.toString(), Toast.LENGTH_SHORT).show();
                    }
                })
```
