### PR TITLE
Log forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ You can also choose to send the logs to your own custom logger.
 WifiUtils.forwardLog(new Logger() {
             @Override
             public void log(int priority, String tag, String message) {
-                
+                Timber.tag(tag).log(priority, message);
             }
         });
  ```

--- a/README.md
+++ b/README.md
@@ -188,7 +188,18 @@ WifiUtils.withContext(context)
 ```
 
 ### Enable Logging
-If you want to receive some extra logging info comming from WiFi Utils you can enable its logging capabilities with `WifiUtils.enableLog(true);`
+If you want to receive some extra logging info coming from WiFi Utils you can enable its logging capabilities with `WifiUtils.enableLog(true);`
+
+You can also choose to send the logs to your own custom logger.
+
+```java
+WifiUtils.forwardLog(new Logger() {
+            @Override
+            public void log(int priority, String tag, String message) {
+                
+            }
+        });
+ ```
 
 ### Permissions
 Damn You are required to set a few permissions in order for this lib to work correctly :( Also please check [this](https://issuetracker.google.com/issues/37060483) issue

--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Button;
 import android.widget.Toast;
 
@@ -12,6 +13,7 @@ import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 
+import com.thanosfisherman.wifiutils.Logger;
 import com.thanosfisherman.wifiutils.WifiUtils;
 import com.thanosfisherman.wifiutils.wifiConnect.ConnectionErrorCode;
 import com.thanosfisherman.wifiutils.wifiConnect.ConnectionSuccessListener;
@@ -46,6 +48,11 @@ public class MainActivity extends AppCompatActivity {
 
         final Button buttonDisconnect = findViewById(R.id.button_disconnect);
         buttonDisconnect.setOnClickListener(v -> disconnect(v.getContext()));
+
+        WifiUtils.forwardLog((priority, tag, message) ->  {
+            String customTag = tag + "_" + MainActivity.class.getSimpleName();
+            Log.i(customTag, message);
+        });
     }
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)

--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainKotlinActivity.kt
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainKotlinActivity.kt
@@ -3,6 +3,7 @@ package com.thanosfisherman.wifiutils.sample
 import android.Manifest
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
@@ -24,6 +25,10 @@ class MainKotlinActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.ACCESS_FINE_LOCATION), 555)
+        WifiUtils.forwardLog{ _, tag, message ->
+            val customTag = "${tag}.${this::class.simpleName}"
+            Log.i(customTag, message)
+        }
         WifiUtils.enableLog(true)
         textview_ssid.text = SSID
         textview_password.text = PASSWORD

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/Logger.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/Logger.java
@@ -1,0 +1,5 @@
+package com.thanosfisherman.wifiutils;
+
+public interface Logger {
+    void log(int priority, String tag, String message);
+}

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiUtils.java
@@ -58,6 +58,8 @@ public final class WifiUtils implements WifiConnectorBuilder,
     @NonNull
     private final Context mContext;
     private static boolean mEnableLog;
+    @Nullable
+    private static Logger customLogger;
     private long mWpsTimeoutMillis = 30000;
     private long mTimeoutMillis = 30000;
     @NonNull
@@ -197,12 +199,24 @@ public final class WifiUtils implements WifiConnectorBuilder,
 
     public static void wifiLog(final String text) {
         if (mEnableLog) {
-            Log.d(TAG, "WifiUtils: " + text);
+            Logger logger = of(customLogger).orElse((priority, tag, message) -> {
+                Log.println(priority, TAG, message);
+            });
+            logger.log(Log.VERBOSE, TAG, text);
         }
     }
 
     public static void enableLog(final boolean enabled) {
         mEnableLog = enabled;
+    }
+
+    /**
+     * Send logs to a custom logging implementation. If none specified, defaults to logcat.
+     *
+     * @param logger custom logger
+     */
+    public static void forwardLog(Logger logger) {
+        WifiUtils.customLogger = logger;
     }
 
     @Override


### PR DESCRIPTION
#### Description

Currently the library only outputs to logcat.

#### Solution

Allow user to pass in their implementation of a Logger interface, which is then used by the wifiLog function. If unavailable, just send to logcat the same as before.

Closes #74