### PR TITLE
sample: make SSID & password editable

### DIFF
--- a/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.kt
+++ b/sample/src/main/java/com/thanosfisherman/wifiutils/sample/MainActivity.kt
@@ -24,9 +24,6 @@ import java.util.concurrent.Executors
 
 class MainActivity : AppCompatActivity() {
 
-    private val SSID = "lelelelelel"
-    private val PASSWORD = "psaridis"
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -36,8 +33,6 @@ class MainActivity : AppCompatActivity() {
             Log.i(customTag, message)
         }
         WifiUtils.enableLog(true)
-        textview_ssid.text = SSID
-        textview_password.text = PASSWORD
         button_connect.setOnClickListener { connectWithWpa(applicationContext) }
         button_connect_hidden.setOnClickListener { connectHidden(applicationContext) }
         button_disconnect.setOnClickListener { disconnect(applicationContext) }
@@ -48,7 +43,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun connectWithWpa(context: Context) {
         WifiUtils.withContext(context)
-                .connectWith(SSID, PASSWORD)
+                .connectWith(textview_ssid.text.toString(), textview_password.text.toString())
                 .setTimeout(15000)
                 .onConnectionResult(object : ConnectionSuccessListener {
                     override fun success() {
@@ -64,7 +59,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun connectHidden(context: Context) {
         WifiUtils.withContext(context)
-                .connectWith(SSID, PASSWORD,TypeEnum.EAP)
+                .connectWith(textview_ssid.text.toString(), textview_password.text.toString(),TypeEnum.EAP)
                 .onConnectionResult(object : ConnectionSuccessListener {
                     override fun success() {
                         Toast.makeText(context, "SUCCESS!", Toast.LENGTH_SHORT).show()
@@ -92,7 +87,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun remove(context: Context) {
         WifiUtils.withContext(context)
-                .remove(SSID, object : RemoveSuccessListener {
+                .remove(textview_ssid.text.toString(), object : RemoveSuccessListener {
                     override fun success() {
                         Toast.makeText(context, "Remove success!", Toast.LENGTH_SHORT).show()
                     }
@@ -104,7 +99,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun check(context: Context) {
-        val result = WifiUtils.withContext(context).isWifiConnected(SSID)
+        val result = WifiUtils.withContext(context).isWifiConnected(textview_ssid.text.toString())
         Toast.makeText(context, "Wifi Connect State: $result", Toast.LENGTH_SHORT).show()
     }
 

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -7,22 +7,26 @@
     android:layout_height="match_parent"
     tools:context="com.thanosfisherman.wifiutils.sample.MainActivity">
 
-    <TextView
+    <EditText
         android:id="@+id/textview_ssid"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
+        android:hint="Enter SSID"
+        android:minWidth="200dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintBottom_toTopOf="@id/textview_password"
         tools:text="SSID"
         />
 
-    <TextView
+    <EditText
         android:id="@+id/textview_password"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toBottomOf="@id/textview_ssid"
+        android:hint="Enter Password"
+        android:minWidth="200dp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintBottom_toTopOf="@id/button_connect"


### PR DESCRIPTION
#### Description

Remove the hardcoded SSID and password from the sample application and replace them with an EditText so the user can enter it at runtime.

If a user still wants to hardcode the credentials, they can add this to onCreate:
```
textview_ssid.text = "foo"
textview_password.text = "bar"
```