### PR TITLE
Feature: Add pattern match for Wifi name

### DIFF
--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConnectorUtils.java
@@ -19,6 +19,7 @@ import android.net.wifi.WifiManager;
 import android.net.wifi.WifiNetworkSpecifier;
 import android.net.wifi.WpsInfo;
 import android.os.Build;
+import android.os.PatternMatcher;
 import android.provider.Settings;
 
 import androidx.annotation.NonNull;
@@ -235,13 +236,13 @@ public final class ConnectorUtils {
     }
 
     @RequiresPermission(allOf = {ACCESS_FINE_LOCATION, ACCESS_WIFI_STATE})
-    static boolean connectToWifi(@NonNull final Context context, @Nullable final WifiManager wifiManager, @Nullable final ConnectivityManager connectivityManager, @NonNull WeakHandler handler, @NonNull final ScanResult scanResult, @NonNull final String password, @NonNull WifiConnectionCallback wifiConnectionCallback) {
+    static boolean connectToWifi(@NonNull final Context context, @Nullable final WifiManager wifiManager, @Nullable final ConnectivityManager connectivityManager, @NonNull WeakHandler handler, @NonNull final ScanResult scanResult, @NonNull final String password, @NonNull WifiConnectionCallback wifiConnectionCallback, boolean patternMatch) {
         if (wifiManager == null || connectivityManager == null) {
             return false;
         }
 
         if (isAndroidQOrLater()) {
-            return connectAndroidQ(wifiManager, connectivityManager, handler, wifiConnectionCallback, scanResult, password);
+            return connectAndroidQ(wifiManager, connectivityManager, handler, wifiConnectionCallback, scanResult, password, patternMatch);
         }
 
         return connectPreAndroidQ(context, wifiManager, scanResult, password);
@@ -397,14 +398,20 @@ public final class ConnectorUtils {
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    private static boolean connectAndroidQ(@Nullable WifiManager wifiManager, @Nullable ConnectivityManager connectivityManager, @NonNull WeakHandler handler, @NonNull WifiConnectionCallback wifiConnectionCallback, @NonNull ScanResult scanResult, @NonNull String password) {
+    private static boolean connectAndroidQ(@Nullable WifiManager wifiManager, @Nullable ConnectivityManager connectivityManager, @NonNull WeakHandler handler, @NonNull WifiConnectionCallback wifiConnectionCallback, @NonNull ScanResult scanResult, @NonNull String password, boolean patternMatch) {
         if (connectivityManager == null) {
             return false;
         }
 
-        WifiNetworkSpecifier.Builder wifiNetworkSpecifierBuilder = new WifiNetworkSpecifier.Builder()
-                .setSsid(scanResult.SSID)
-                .setBssid(MacAddress.fromString(scanResult.BSSID));
+        WifiNetworkSpecifier.Builder wifiNetworkSpecifierBuilder = new WifiNetworkSpecifier.Builder();
+
+        if (patternMatch) {
+            wifiNetworkSpecifierBuilder.setSsidPattern(new PatternMatcher(scanResult.SSID, PatternMatcher.PATTERN_PREFIX));
+        } else {
+            wifiNetworkSpecifierBuilder
+                    .setSsid(scanResult.SSID)
+                    .setBssid(MacAddress.fromString(scanResult.BSSID));
+        }
 
         final String security = ConfigSecurities.getSecurity(scanResult);
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiConnectorBuilder.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiConnectorBuilder.java
@@ -35,6 +35,9 @@ public interface WifiConnectorBuilder {
 
         WifiSuccessListener connectWith(@NonNull String ssid, @NonNull String password, @NonNull TypeEnum type);
 
+        @NonNull
+        WifiUtilsBuilder patternMatch();
+
         @Deprecated
         void disconnectFrom(@NonNull String ssid, @NonNull DisconnectionSuccessListener disconnectionSuccessListener);
 

--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiUtils.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/WifiUtils.java
@@ -99,6 +99,8 @@ public final class WifiUtils implements WifiConnectorBuilder,
     private WifiStateListener mWifiStateListener;
     @Nullable
     private ConnectionWpsListener mConnectionWpsListener;
+    @Nullable
+    private boolean mPatternMatch;
 
     @NonNull
     private final WifiStateCallback mWifiStateCallback = new WifiStateCallback() {
@@ -154,7 +156,7 @@ public final class WifiUtils implements WifiConnectorBuilder,
                 }
             }
             if (mSingleScanResult != null && mPassword != null) {
-                if (connectToWifi(mContext, mWifiManager, mConnectivityManager, mHandler, mSingleScanResult, mPassword, mWifiConnectionCallback)) {
+                if (connectToWifi(mContext, mWifiManager, mConnectivityManager, mHandler, mSingleScanResult, mPassword, mWifiConnectionCallback, mPatternMatch)) {
                     registerReceiver(mContext, (mWifiConnectionReceiver).connectWith(mSingleScanResult, mPassword, mConnectivityManager),
                             new IntentFilter(WifiManager.SUPPLICANT_STATE_CHANGED_ACTION));
                     registerReceiver(mContext, mWifiConnectionReceiver,
@@ -330,6 +332,14 @@ public final class WifiUtils implements WifiConnectorBuilder,
                 removeSuccessListener.failed(RemoveErrorCode.COULD_NOT_REMOVE);
             }
         }
+    }
+
+    @NonNull
+    @Override
+    public WifiUtilsBuilder patternMatch() {
+        mPatternMatch = true;
+
+        return this;
     }
 
     @NonNull


### PR DESCRIPTION
#### Description
Usage:
```
WifiUtils.withContext(context)
                .patternMatch()
                .connectWith(....
```
Now android Q+ will prompt about matching Wifi networks list.
Example usage: I have USB dongle which emits its own WiFi and I need to connect with it without knowing its name, only first part of name, eg. `RS-43144` where prefix is `RS-`

Closes #111 

#### Solution

use `setSsidPattern` from API
