### PR TITLE
Avoid a null pointer exception on some old devices

### DIFF
--- a/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
+++ b/wifiutils/src/main/java/com/thanosfisherman/wifiutils/ConfigSecurities.java
@@ -176,7 +176,7 @@ final class ConfigSecurities {
         final String findSSID = ('"' + ssid + '"');
 
         for (final WifiConfiguration wifiConfiguration : configuredNetworks) {
-            if (wifiConfiguration.SSID.equals(findSSID)) {
+            if (wifiConfiguration.SSID != null && wifiConfiguration.SSID.equals(findSSID)) {
                 return wifiConfiguration;
             }
         }


### PR DESCRIPTION
#### Description

Some legacy devices somehow manage to return a WiFiConfiguration object with a `null` SSID. 

#### Solution

This PR simply checks if the WiFiConfiguration being iterated has a `null` SSID
